### PR TITLE
Add GitHub profile fetching skill with parallel API calls

### DIFF
--- a/skills/git/github-profile/SKILL.md
+++ b/skills/git/github-profile/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: github-profile
+description: Fetch and display GitHub user profiles with stats, repositories, and recent activity. Use when the user asks to look up a GitHub user, check someone's GitHub profile, see repos/activity of a developer, or needs GitHub user information. Triggers on keywords like "github profile", "github user", "who is @username", "repos of", "github activity".
+---
+
+# GitHub Profile
+
+Fetch comprehensive GitHub user profile data via the GitHub API, including bio, stats, top repositories, and recent public activity.
+
+## What It Does
+
+Given a GitHub username, this skill:
+1. Fetches the user's profile (name, bio, company, location, followers)
+2. Lists their top 10 most recently updated repositories
+3. Summarizes recent public activity (last 30 events)
+
+## Requirements
+
+- `curl` (available in virtually all environments)
+- `python3` (for JSON parsing — no `jq` dependency)
+- Optional: `GITHUB_TOKEN` env var for higher rate limits
+
+## Bundled Script
+
+The main script is `scripts/fetch-profile.sh`. It:
+- Fetches profile, repos, and events **in parallel** (3 concurrent curl calls)
+- Parses JSON with python3 heredoc (no external dependencies)
+- Outputs formatted Markdown tables
+- Automatically extracts GitHub token from git remote URL if available
+
+### Usage
+
+```bash
+bash scripts/fetch-profile.sh <github-username>
+```
+
+### Output Format
+
+```
+## GitHub Profile: octocat
+
+**Name:** The Octocat
+**Company:** @github
+**Location:** San Francisco
+**Profile:** https://github.com/octocat
+
+### Stats
+| Metric | Value |
+|--------|-------|
+| Public Repos | 8 |
+| Followers | 22034 |
+| Member Since | Jan 2011 |
+
+### Top Repositories (by recent update)
+| Repository | Stars | Forks | Language | Updated |
+|------------|-------|-------|----------|---------|
+| Spoon-Knife | 13660 | 156628 | HTML | 12/03/2026 |
+...
+
+### Recent Activity (last 30 public events)
+| Event Type | Count |
+|------------|-------|
+| Push | 12 |
+| PullRequest | 5 |
+...
+```
+
+## Installing in a Project
+
+This skill is agnostic — it lives in this repo as reference but must be installed into each project that wants to use it as a slash command.
+
+### Installation Steps
+
+1. Copy the script into your project:
+
+```bash
+mkdir -p scripts/github-profile
+cp <path-to-agnostic-core>/skills/git/github-profile/scripts/fetch-profile.sh \
+   scripts/github-profile/fetch-profile.sh
+chmod +x scripts/github-profile/fetch-profile.sh
+```
+
+2. Create the slash command at `.claude/commands/github-profile.md`:
+
+```markdown
+# GitHub Profile
+
+Busca e exibe o perfil completo de um usuario do GitHub.
+
+## Argumento recebido: `$ARGUMENTS`
+
+## Instrucoes
+
+1. Interprete `$ARGUMENTS` como o username do GitHub.
+   - Se vazio, pergunte ao usuario qual username deseja consultar.
+   - Se contiver `@`, remova (ex: `@octocat` -> `octocat`).
+   - Se contiver URL GitHub, extraia apenas o username.
+
+2. Execute o script:
+   ```bash
+   bash scripts/github-profile/fetch-profile.sh <username>
+   ```
+
+3. Apresente o resultado formatado em markdown.
+
+4. Se falhar: mostre o erro, sugira verificar username ou definir GITHUB_TOKEN.
+
+## Regras
+- NUNCA exponha tokens GitHub no output
+```
+
+Commit both files and the command is ready as `/github-profile <username>`.
+
+## Verification
+
+After installing, test with:
+
+```bash
+bash scripts/github-profile/fetch-profile.sh octocat
+```
+
+Expected: Markdown table with Octocat's profile, 8 repos, and recent activity.

--- a/skills/git/github-profile/scripts/fetch-profile.sh
+++ b/skills/git/github-profile/scripts/fetch-profile.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# fetch-profile.sh — Fetch and display a GitHub user profile in Markdown
+# Usage: bash fetch-profile.sh <github-username>
+# Optional: set GITHUB_TOKEN env var for higher API rate limits
+
+set -euo pipefail
+
+USERNAME="${1:-}"
+
+if [[ -z "$USERNAME" ]]; then
+  echo "Usage: $0 <github-username>" >&2
+  exit 1
+fi
+
+# Strip leading @ if present
+USERNAME="${USERNAME#@}"
+
+# ── Token resolution ──────────────────────────────────────────────────────────
+# 1. Prefer GITHUB_TOKEN env var
+# 2. Try to extract token embedded in git remote URL (https://<token>@github.com/...)
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  REMOTE_URL="$(git remote get-url origin 2>/dev/null || true)"
+  if [[ "$REMOTE_URL" =~ https://([^@]+)@github\.com ]]; then
+    GITHUB_TOKEN="${BASH_REMATCH[1]}"
+  fi
+fi
+
+# Build auth header
+AUTH_HEADER=""
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
+fi
+
+# ── Temp files ────────────────────────────────────────────────────────────────
+TMP_DIR="$(mktemp -d)"
+PROFILE_FILE="$TMP_DIR/profile.json"
+REPOS_FILE="$TMP_DIR/repos.json"
+EVENTS_FILE="$TMP_DIR/events.json"
+
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+# ── Parallel curl calls ───────────────────────────────────────────────────────
+BASE="https://api.github.com"
+CURL_OPTS=(-s --max-time 15)
+[[ -n "$AUTH_HEADER" ]] && CURL_OPTS+=(-H "$AUTH_HEADER")
+CURL_OPTS+=(-H "Accept: application/vnd.github.v3+json")
+CURL_OPTS+=(-H "User-Agent: fetch-profile-sh")
+
+curl "${CURL_OPTS[@]}" "$BASE/users/$USERNAME"                                 \
+  -o "$PROFILE_FILE" &
+curl "${CURL_OPTS[@]}" "$BASE/users/$USERNAME/repos?sort=updated&per_page=10"  \
+  -o "$REPOS_FILE" &
+curl "${CURL_OPTS[@]}" "$BASE/users/$USERNAME/events/public?per_page=30"       \
+  -o "$EVENTS_FILE" &
+wait
+
+# ── Validate responses ────────────────────────────────────────────────────────
+for f in "$PROFILE_FILE" "$REPOS_FILE" "$EVENTS_FILE"; do
+  if [[ ! -s "$f" ]]; then
+    echo "Error: failed to fetch data from GitHub API (empty response)." >&2
+    echo "Check the username or define GITHUB_TOKEN for higher rate limits." >&2
+    exit 1
+  fi
+  # Detect API error messages
+  if python3 -c "import json,sys; d=json.load(open('$f')); sys.exit(0 if 'message' not in d else 1)" 2>/dev/null; then
+    : # ok
+  else
+    MSG="$(python3 -c "import json; d=json.load(open('$f')); print(d.get('message','Unknown error'))" 2>/dev/null || echo "Unknown error")"
+    echo "Error from GitHub API: $MSG" >&2
+    exit 1
+  fi
+done
+
+# ── Python3 parsing & output ──────────────────────────────────────────────────
+python3 - "$PROFILE_FILE" "$REPOS_FILE" "$EVENTS_FILE" << 'PYEOF'
+import json
+import sys
+from datetime import datetime
+from collections import Counter
+
+profile_file, repos_file, events_file = sys.argv[1], sys.argv[2], sys.argv[3]
+
+with open(profile_file) as f:
+    p = json.load(f)
+with open(repos_file) as f:
+    repos = json.load(f)
+with open(events_file) as f:
+    events = json.load(f)
+
+# ── Header ────────────────────────────────────────────────────────────────────
+print(f"## GitHub Profile: {p.get('login', 'N/A')}\n")
+
+if p.get("name"):
+    print(f"**Name:** {p['name']}")
+if p.get("bio"):
+    print(f"**Bio:** {p['bio']}")
+if p.get("company"):
+    print(f"**Company:** {p['company']}")
+if p.get("location"):
+    print(f"**Location:** {p['location']}")
+print(f"**Profile:** https://github.com/{p.get('login', '')}")
+print()
+
+# ── Stats table ───────────────────────────────────────────────────────────────
+created = p.get("created_at", "")
+if created:
+    try:
+        dt = datetime.strptime(created, "%Y-%m-%dT%H:%M:%SZ")
+        member_since = dt.strftime("%b %Y")
+    except ValueError:
+        member_since = created[:7]
+else:
+    member_since = "N/A"
+
+print("### Stats")
+print("| Metric | Value |")
+print("|--------|-------|")
+print(f"| Public Repos | {p.get('public_repos', 0)} |")
+print(f"| Followers | {p.get('followers', 0)} |")
+print(f"| Following | {p.get('following', 0)} |")
+print(f"| Public Gists | {p.get('public_gists', 0)} |")
+print(f"| Member Since | {member_since} |")
+print()
+
+# ── Top repositories table ────────────────────────────────────────────────────
+print("### Top Repositories (by recent update)")
+print("| Repository | Stars | Forks | Language | Updated |")
+print("|------------|-------|-------|----------|---------|")
+
+for repo in repos:
+    if not isinstance(repo, dict):
+        continue
+    name = repo.get("name", "N/A")
+    stars = repo.get("stargazers_count", 0)
+    forks = repo.get("forks_count", 0)
+    lang = repo.get("language") or "—"
+    updated_raw = repo.get("updated_at", "")
+    if updated_raw:
+        try:
+            dt = datetime.strptime(updated_raw, "%Y-%m-%dT%H:%M:%SZ")
+            updated = dt.strftime("%d/%m/%Y")
+        except ValueError:
+            updated = updated_raw[:10]
+    else:
+        updated = "N/A"
+    print(f"| {name} | {stars} | {forks} | {lang} | {updated} |")
+
+print()
+
+# ── Recent activity table ─────────────────────────────────────────────────────
+print("### Recent Activity (last 30 public events)")
+print("| Event Type | Count |")
+print("|------------|-------|")
+
+event_counts: Counter = Counter()
+for ev in events:
+    if not isinstance(ev, dict):
+        continue
+    raw_type = ev.get("type", "Unknown")
+    # Trim "Event" suffix for readability (e.g. "PushEvent" -> "Push")
+    label = raw_type.replace("Event", "") if raw_type.endswith("Event") else raw_type
+    event_counts[label] += 1
+
+if event_counts:
+    for event_type, count in event_counts.most_common():
+        print(f"| {event_type} | {count} |")
+else:
+    print("| (no recent public activity) | — |")
+
+PYEOF


### PR DESCRIPTION
## Summary

This PR introduces a new skill for fetching and displaying GitHub user profiles in Markdown format. It includes a bash script that queries the GitHub API in parallel and formats the results as structured tables.

## Key Changes

- **Added `scripts/fetch-profile.sh`**: A bash script that:
  - Fetches user profile, repositories, and public events from GitHub API in parallel (3 concurrent curl calls)
  - Parses JSON responses using Python 3 (no external dependencies like `jq`)
  - Automatically resolves GitHub authentication token from environment variable or git remote URL
  - Outputs comprehensive Markdown-formatted profile data including stats, top repositories, and recent activity
  - Includes proper error handling, validation, and cleanup

- **Added `SKILL.md`**: Documentation covering:
  - Skill description and use cases
  - Requirements and dependencies
  - Usage instructions and output format examples
  - Installation steps for integrating into projects
  - Sample slash command implementation
  - Verification instructions

## Implementation Details

- **Parallel execution**: Uses background curl processes with `wait` to fetch three API endpoints concurrently, improving performance
- **Token handling**: Intelligently resolves GitHub token from `GITHUB_TOKEN` env var or extracts from git remote URL for seamless authentication
- **Robust parsing**: Python 3 heredoc validates JSON responses and detects API errors before processing
- **Markdown output**: Generates three formatted tables (stats, repositories, activity) with proper date formatting and fallback values
- **Error handling**: Validates all responses, provides helpful error messages, and cleans up temporary files via trap

https://claude.ai/code/session_013GSWY5dR8Q3H1d7LMPy7YS