### PR TITLE
docs: reforçar CLAUDE.md inicial com diretivas de orquestração

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,12 @@ Este é o **agnostic-core**: acervo de skills, agents e commands em Markdown pur
 - Commits seguem [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`.
 - PRs têm `master` como base, com summary + test plan.
 
+## Princípios básicos
+
+- **Simplicidade primeiro**: faça cada mudança em uma skill a mais simples possível; evite reescrever a skill inteira por um detalhe.
+- **Sem previsão**: encontre causas-raiz; sem fixes temporários para passar lint/check-refs; padrões de dev sênior.
+- **Impacto mínimo**: toque apenas no que é necessário; sem efeitos colaterais que quebrem skills relacionadas.
+
 ## Modo de Output
 
 **Caveman ativo por padrão em toda sessão.**

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -1,0 +1,9 @@
+# Lições aprendidas
+
+Capture aqui padrões identificados em correções do usuário, para evitar repetição em sessões futuras.
+
+Formato sugerido para cada lição:
+
+- **Padrão observado**: o que foi feito de errado.
+- **Correção aplicada**: o que o usuário pediu para mudar.
+- **Regra para si mesmo**: como evitar o mesmo erro no futuro.

--- a/templates/project-bootstrap/api-backend/CLAUDE.md
+++ b/templates/project-bootstrap/api-backend/CLAUDE.md
@@ -65,6 +65,56 @@ Convencoes do projeto (preencher):
   Estilo de commits: Conventional Commits
 
 ---
+
+Orquestração do fluxo de trabalho:
+
+  Plan mode (padrão):
+    - Entre em plan mode para qualquer tarefa não-trivial (3+ etapas ou decisões arquiteturais).
+    - Se algo der errado durante a execução, pare e replanjeje antes de prosseguir.
+    - Use plan mode também para etapas de verificação, não apenas para construção.
+    - Escreva especificações detalhadas antes de codar para reduzir ambiguidade.
+
+  Subagentes:
+    - Use subagentes liberalmente para manter a janela de contexto principal limpa.
+    - Offload pesquisa, exploração e análise paralela para subagentes.
+    - Uma tarefa por subagente — execução focada.
+
+  Loop de auto-aperfeiçoamento:
+    - Após qualquer correção do usuário, atualize tasks/lessons.md com o padrão identificado.
+    - Escreva regras para si mesmo que previnam o mesmo erro.
+    - No início da sessão, releia tasks/lessons.md para o projeto atual.
+
+  Verificação antes de concluir:
+    - Nunca marque uma tarefa como concluída sem provar que funciona.
+    - Execute testes, verifique logs, demonstre a correção.
+    - Pergunta padrão: "Um engenheiro de equipe aprovaria isso?"
+
+  Exigência de elegância (equilibrada):
+    - Para mudanças não-triviais, pause e pergunte: "existe uma maneira mais elegante?"
+    - Se uma correção parecer paliativa: "Sabendo o que sei agora, implemente a solução elegante."
+    - Para fixes simples e óbvios, pule este passo — não super-engenhe.
+
+  Correção de bugs autônoma:
+    - Ao receber um relatório de bug: apenas conserte. Não peça ajuda.
+    - Aponte para logs, erros, testes falhando — depois resolva.
+    - Zero troca de contexto exigida do usuário.
+
+Gerenciamento de tarefas:
+
+  1. Plano primeiro:        escreva o plano em tasks/todo.md com itens marcáveis.
+  2. Verifique o plano:     valide antes de iniciar a implementação.
+  3. Acompanhe o progresso: marque os itens conforme avança.
+  4. Explique as mudanças:  resumo de alto nível a cada etapa.
+  5. Documente resultados:  seção de revisão no fim de tasks/todo.md.
+  6. Capture lições:        atualize tasks/lessons.md após correções do usuário.
+
+Princípios básicos:
+
+  - Simplicidade primeiro:  faça cada mudança a mais simples possível; impacto mínimo.
+  - Sem previsão:           encontre causas-raiz; sem fixes temporários; padrões de dev sênior.
+  - Impacto mínimo:         toque apenas no que é necessário; sem efeitos colaterais.
+
+---
 Comportamento
   Ao iniciar cada sessão, execute automaticamente o comando /status.
   Status panel skill:  .agnostic-core/skills/ai/project-status.md

--- a/templates/project-bootstrap/frontend/CLAUDE.md
+++ b/templates/project-bootstrap/frontend/CLAUDE.md
@@ -83,6 +83,56 @@ Convencoes do projeto (preencher):
   Estilo de commits: Conventional Commits
 
 ---
+
+Orquestração do fluxo de trabalho:
+
+  Plan mode (padrão):
+    - Entre em plan mode para qualquer tarefa não-trivial (3+ etapas ou decisões arquiteturais).
+    - Se algo der errado durante a execução, pare e replanjeje antes de prosseguir.
+    - Use plan mode também para etapas de verificação, não apenas para construção.
+    - Escreva especificações detalhadas antes de codar para reduzir ambiguidade.
+
+  Subagentes:
+    - Use subagentes liberalmente para manter a janela de contexto principal limpa.
+    - Offload pesquisa, exploração e análise paralela para subagentes.
+    - Uma tarefa por subagente — execução focada.
+
+  Loop de auto-aperfeiçoamento:
+    - Após qualquer correção do usuário, atualize tasks/lessons.md com o padrão identificado.
+    - Escreva regras para si mesmo que previnam o mesmo erro.
+    - No início da sessão, releia tasks/lessons.md para o projeto atual.
+
+  Verificação antes de concluir:
+    - Nunca marque uma tarefa como concluída sem provar que funciona.
+    - Execute testes, verifique logs, demonstre a correção.
+    - Pergunta padrão: "Um engenheiro de equipe aprovaria isso?"
+
+  Exigência de elegância (equilibrada):
+    - Para mudanças não-triviais, pause e pergunte: "existe uma maneira mais elegante?"
+    - Se uma correção parecer paliativa: "Sabendo o que sei agora, implemente a solução elegante."
+    - Para fixes simples e óbvios, pule este passo — não super-engenhe.
+
+  Correção de bugs autônoma:
+    - Ao receber um relatório de bug: apenas conserte. Não peça ajuda.
+    - Aponte para logs, erros, testes falhando — depois resolva.
+    - Zero troca de contexto exigida do usuário.
+
+Gerenciamento de tarefas:
+
+  1. Plano primeiro:        escreva o plano em tasks/todo.md com itens marcáveis.
+  2. Verifique o plano:     valide antes de iniciar a implementação.
+  3. Acompanhe o progresso: marque os itens conforme avança.
+  4. Explique as mudanças:  resumo de alto nível a cada etapa.
+  5. Documente resultados:  seção de revisão no fim de tasks/todo.md.
+  6. Capture lições:        atualize tasks/lessons.md após correções do usuário.
+
+Princípios básicos:
+
+  - Simplicidade primeiro:  faça cada mudança a mais simples possível; impacto mínimo.
+  - Sem previsão:           encontre causas-raiz; sem fixes temporários; padrões de dev sênior.
+  - Impacto mínimo:         toque apenas no que é necessário; sem efeitos colaterais.
+
+---
 Comportamento
   Ao iniciar cada sessão, execute automaticamente o comando /status.
   Status panel skill:  .agnostic-core/skills/ai/project-status.md

--- a/templates/project-bootstrap/fullstack/CLAUDE.md
+++ b/templates/project-bootstrap/fullstack/CLAUDE.md
@@ -118,6 +118,56 @@ Convencoes do projeto (preencher):
   Estilo de commits: Conventional Commits
 
 ---
+
+Orquestração do fluxo de trabalho:
+
+  Plan mode (padrão):
+    - Entre em plan mode para qualquer tarefa não-trivial (3+ etapas ou decisões arquiteturais).
+    - Se algo der errado durante a execução, pare e replanjeje antes de prosseguir.
+    - Use plan mode também para etapas de verificação, não apenas para construção.
+    - Escreva especificações detalhadas antes de codar para reduzir ambiguidade.
+
+  Subagentes:
+    - Use subagentes liberalmente para manter a janela de contexto principal limpa.
+    - Offload pesquisa, exploração e análise paralela para subagentes.
+    - Uma tarefa por subagente — execução focada.
+
+  Loop de auto-aperfeiçoamento:
+    - Após qualquer correção do usuário, atualize tasks/lessons.md com o padrão identificado.
+    - Escreva regras para si mesmo que previnam o mesmo erro.
+    - No início da sessão, releia tasks/lessons.md para o projeto atual.
+
+  Verificação antes de concluir:
+    - Nunca marque uma tarefa como concluída sem provar que funciona.
+    - Execute testes, verifique logs, demonstre a correção.
+    - Pergunta padrão: "Um engenheiro de equipe aprovaria isso?"
+
+  Exigência de elegância (equilibrada):
+    - Para mudanças não-triviais, pause e pergunte: "existe uma maneira mais elegante?"
+    - Se uma correção parecer paliativa: "Sabendo o que sei agora, implemente a solução elegante."
+    - Para fixes simples e óbvios, pule este passo — não super-engenhe.
+
+  Correção de bugs autônoma:
+    - Ao receber um relatório de bug: apenas conserte. Não peça ajuda.
+    - Aponte para logs, erros, testes falhando — depois resolva.
+    - Zero troca de contexto exigida do usuário.
+
+Gerenciamento de tarefas:
+
+  1. Plano primeiro:        escreva o plano em tasks/todo.md com itens marcáveis.
+  2. Verifique o plano:     valide antes de iniciar a implementação.
+  3. Acompanhe o progresso: marque os itens conforme avança.
+  4. Explique as mudanças:  resumo de alto nível a cada etapa.
+  5. Documente resultados:  seção de revisão no fim de tasks/todo.md.
+  6. Capture lições:        atualize tasks/lessons.md após correções do usuário.
+
+Princípios básicos:
+
+  - Simplicidade primeiro:  faça cada mudança a mais simples possível; impacto mínimo.
+  - Sem previsão:           encontre causas-raiz; sem fixes temporários; padrões de dev sênior.
+  - Impacto mínimo:         toque apenas no que é necessário; sem efeitos colaterais.
+
+---
 Comportamento
   Ao iniciar cada sessão, execute automaticamente o comando /status.
   Status panel skill:  .agnostic-core/skills/ai/project-status.md


### PR DESCRIPTION
## Summary

- Adiciona seção **Orquestração do fluxo de trabalho** + **Gerenciamento de tarefas** + **Princípios básicos** nos 3 templates de bootstrap (fullstack, api-backend, frontend), incorporando as diretivas comportamentais do arquivo Boris Cherny enviado pelo usuário. Posicionada entre "Convenções do projeto" e "Comportamento", preservando o padrão visual dos templates (sem `#`, indentação 2 espaços, separadores `---`).
- No `CLAUDE.md` do próprio repo, acrescenta apenas a seção **Princípios básicos** adaptada ao contexto de contribuir ao agnostic-core (skills agnósticas). Plan mode e Loop de auto-aperfeiçoamento foram intencionalmente omitidos do CLAUDE.md do repo (decisão do usuário).
- Cria `docs/lessons.md` como placeholder do loop de auto-aperfeiçoamento.
- Os scripts `install.sh`, `install.ps1` e `npx-entry.js` **não precisam mudar** — apenas copiam o template, então pegam o reforço automaticamente. A nova seção é puramente comportamental (sem paths `.agnostic-core/...`), portanto não cria pontos de falha em `check-refs`.

## Test plan

- [x] `npm run lint` — 0 errors em 145 arquivos
- [x] `npm run check-refs` — OK
- [x] `diff` entre os 3 templates limitado às novas seções — idêntico caractere a caractere
- [x] Posicionamento confirmado: Orquestração → Gerenciamento → Princípios → `---` → Comportamento
- [ ] Smoke test do template (cp para diretório limpo) — recomendado validar manualmente após merge


---
_Generated by [Claude Code](https://claude.ai/code/session_01FujgWKoEJZVxS2QCDabaax)_